### PR TITLE
New encoding of in tuple compatible format.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+  "bytes"
+  "testing"
+)
+
+func TestGraphiteEncoder(t *testing.T) {
+  cs := []struct {
+        ts int64
+        val float64
+        want []byte
+  }{
+    //                   fx[2] int   float float....................................value
+    // python string x92d\xcb@Y\x00\x00\x00\x00\x00\x00
+    {0x64, 100.0, []byte{0x92, 0x64, 0xcb, 0x40, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},},
+    {0x01, 1.0,   []byte{0x92, 0x01, 0xcb, 0x3F, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},},
+  }
+  e := newGraphiteEncoder()
+  for _, c := range cs {
+    e.buffer.Reset()
+    e.encodeInt64Float64Tuple(c.ts, c.val)
+    res := e.buffer.Bytes()
+    if !bytes.Equal(res, c.want) {
+      t.Fatal(res, c.want)
+    }
+  }
+}


### PR DESCRIPTION
Timestamp and value are now encoded as message pack
arrays, meaning they can unpack as tuples in Python.

Handling this, is a new graphite encoder having one method.
It's a struct which keeps a reference to the backing messages
pack encoder. The struct was introduced to keep the message
pack encoder around, for performance, and because the message
pack encoder struct does not allow access to the buffer. Thus
making extending difficult.

Move main test to top level.
